### PR TITLE
Update R_affx_clf_pgf_parser.cpp

### DIFF
--- a/src/R_affx_clf_pgf_parser.cpp
+++ b/src/R_affx_clf_pgf_parser.cpp
@@ -105,7 +105,7 @@ R_affx_get_body(PgfFile* pgf, SEXP rho, SEXP indices)
 
     while (pgf->next_probeset() == TSV_OK) {
         if(readLimit != 0){
-            if(INTEGER(indices)[nProbesets] != i++){
+            if((INTEGER(indices)[nProbesets] - 1) != i++){
                 continue;
             }
         }
@@ -153,7 +153,7 @@ R_affx_get_body(PgfFile* pgf, SEXP rho, SEXP indices)
     nProbesets = nAtoms = nProbes = i = 0;
     while(pgf->next_probeset() == TSV_OK) {
         if(readLimit != 0){
-            if(INTEGER(indices)[nProbesets] != i++){
+            if((INTEGER(indices)[nProbesets] - 1) != i++){
                 continue;
             }
         }


### PR DESCRIPTION
This change affects reading a Pgf file (via readPgf):
Using the function readPgf(file, indices = NULL) did not read any elements and just returned the header.
This behavior caused trouble, since you cant get the full content of the file without knowing the indices in advance.
Also it looks like other packages assume the body to be read, e.g. in package "pdInfoBuilder" (parsePgfClf >> probesetIdxToTripletIdx)
(most likely the problem for this report: https://stat.ethz.ch/pipermail/bioconductor/2013-May/052768.html)
Plus a change for getting the right indices (imagine an index val of 1, the i++ will be 1 for the first loop, 1-1 != 1).
additional suggestion:
If you want the possibility to just read the header of the file, you should introduce an argument readBody=TRUE to readPgf(), (as described in the according man page), OR to speed up, add a break for indices[0]==0, which currently just loops over the data.

Signed-off-by: Grischa Toedt
